### PR TITLE
Update to present-day methods and functions

### DIFF
--- a/src/info/server.go.tmpl
+++ b/src/info/server.go.tmpl
@@ -5,13 +5,8 @@
 	Author: jo3-l <https://github.com/jo3-l>
 */}}
 
-{{ $icon := "" }}
+{{ $icon := .Guild.IconURL "256" }}
 {{ $name := printf "%s (%d)" .Guild.Name .Guild.ID }}
-{{ if .Guild.Icon }}
-	{{ $ext := "webp" }}
-	{{ if eq (slice .Guild.Icon 0 2) "a_" }} {{ $ext = "gif" }} {{ end }}
-	{{ $icon = printf "https://cdn.discordapp.com/icons/%d/%s.%s" .Guild.ID .Guild.Icon $ext }}
-{{ end }}
 
 {{ $owner := userArg .Guild.OwnerID }}
 {{ $levels := cslice
@@ -26,12 +21,12 @@
 	{{ $afk = printf "**Channel:** <#%d> (%d)\n**Timeout:** %s"
 		.Guild.AfkChannelID
 		.Guild.AfkChannelID
-		(humanizeDurationSeconds (toDuration (mult .Guild.AfkTimeout .TimeSecond)))
+		(mult .Guild.AfkTimeout .TimeSecond | toDuration | humanizeDurationSeconds)
 	}}
 {{ end }}
 {{ $embedsEnabled := "No" }}
 {{ if .Guild.WidgetEnabled }} {{ $embedsEnabled = "Yes" }} {{ end }}
-{{ $createdAt := div .Guild.ID 4194304 | add 1420070400000 | mult 1000000 | toDuration | (newDate 1970 1 1 0 0 0).Add }}
+{{ $createdAt := snowflakeToTime .Guild.ID }}
 
 {{ $infoEmbed := cembed
 	"author" (sdict "name" $name "icon_url" $icon)
@@ -39,7 +34,6 @@
 	"thumbnail" (sdict "url" $icon)
 	"fields" (cslice
 		(sdict "name" "❯ Verification Level" "value" (index $levels .Guild.VerificationLevel))
-		(sdict "name" "❯ Region" "value" .Guild.Region)
 		(sdict "name" "❯ Members" "value" (printf "**• Total:** %d Members\n**• Online:** %d Members" .Guild.MemberCount onlineCount))
 		(sdict "name" "❯ Roles" "value" (printf "**• Total:** %d\nUse `-listroles` to list all roles." (len .Guild.Roles)))
 		(sdict "name" "❯ Owner" "value" (printf "%s (%d)" $owner.String $owner.ID))


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These changes update the custom command to use present-day functions and removes a deprecated field.
- Use `.Guild.IconURL "256"` for guild icon link
- Usage of pipes for readability
- Use `snowflakeToTime` for guild creation date/time
- Remove `.Guild.Region` field from embed (deprecated)

**Status**

- [x] Code changes have been tested on an instance of YAGPDB, or there are no code changes
- [x] I have read and followed the [contribution guide](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/CONTRIBUTING.md)
- [x] I have [written documentation](https://github.com/yagpdb-cc/yagpdb-cc/blob/master/WRITING-DOCUMENTATION.md) for my changes, or there is no need to
